### PR TITLE
multi index paths

### DIFF
--- a/app/kmindex/query2.cpp
+++ b/app/kmindex/query2.cpp
@@ -39,12 +39,21 @@ namespace kmq {
     auto cmd = parser->add_command("query2", "To be used instead of kmindex query when many sub-indexes are registered, i.e. hundreds or thousands.");
 
     auto is_kmq_index = [](const std::string& p, const std::string& v) -> bc::check::checker_ret_t {
-      return std::make_tuple(fs::exists(fmt::format("{}/index.json", v)), bc::utils::format_error(p, v, fmt::format("'{}' is not an index.", v)));
+      auto paths = bc::utils::split(v, ',');
+      for (const auto& path : paths)
+      {
+        if (!fs::exists(path))
+          return std::make_tuple(false, bc::utils::format_error(p, v, fmt::format("'{}' does not exist.", path)));
+        if (!fs::is_directory(path))
+          return std::make_tuple(false, bc::utils::format_error(p, v, fmt::format("'{}' is not a directory.", path)));
+        if (!fs::exists(fmt::format("{}/index.json", path)))
+          return std::make_tuple(false, bc::utils::format_error(p, v, fmt::format("'{}' is not a kmindex index (no index.json).", path)));
+      }
+      return std::make_tuple(true, "");
     };
 
-    cmd->add_param("-i/--index", "Global index path.")
+    cmd->add_param("-i/--index", "Global index path. Multiple comma-separated paths are merged (sub-indexes from all paths are queried together).")
        ->meta("STR")
-       ->checker(bc::check::is_dir)
        ->checker(is_kmq_index)
        ->setter(options->global_index_path);
 
@@ -120,11 +129,21 @@ namespace kmq {
 
     spdlog::info("Loading global index: {}", o->global_index_path);
     Timer load_time;
-    index global(o->global_index_path);
+    auto index_paths = bc::utils::split(o->global_index_path, ',');
+    index global(index_paths[0]);
+    for (std::size_t i = 1; i < index_paths.size(); ++i)
+    {
+      spdlog::info("Merging additional index: {}", index_paths[i]);
+      index other(index_paths[i]);
+      global.merge(other);
+    }
     spdlog::info("Global index loaded ({}).", load_time.formatted());
 
-    spdlog::info(
-      "Global index: '{}'", fs::absolute(o->global_index_path + "/").parent_path().filename().string());
+    if (index_paths.size() > 1)
+      spdlog::info("Global index: merged from {} paths", index_paths.size());
+    else
+      spdlog::info(
+        "Global index: '{}'", fs::absolute(o->global_index_path + "/").parent_path().filename().string());
 
     if (o->index_names.empty())
     {

--- a/lib/include/kmindex/index/index.hpp
+++ b/lib/include/kmindex/index/index.hpp
@@ -23,6 +23,8 @@ namespace kmq {
       void remove_index(const std::string& name);
       bool has_index(const std::string& name);
 
+      void merge(const index& other);
+
       void save() const;
 
       iterator begin();

--- a/lib/src/index/index.cpp
+++ b/lib/src/index/index.cpp
@@ -59,6 +59,16 @@ namespace kmq {
     return m_indexes.count(name) != 0;
   }
 
+  void index::merge(const index& other)
+  {
+    for (const auto& [name, infos] : other.m_indexes)
+    {
+      if (m_indexes.count(name))
+        throw std::runtime_error(fmt::format("Sub-index name collision: '{}' exists in multiple --index paths", name));
+      m_indexes[name] = infos;
+    }
+  }
+
   void index::remove_index(const std::string& name)
   {
     if (m_indexes.count(name))

--- a/tests/app/CMakeLists.txt
+++ b/tests/app/CMakeLists.txt
@@ -9,3 +9,9 @@ add_test(
   COMMAND ${CMAKE_SOURCE_DIR}/tests/app/run_test_abs.sh ${CMAKE_BINARY_DIR}/app/kmindex/kmindex .
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests/data
 )
+
+add_test(
+  NAME kmindex:query2_multi
+  COMMAND ${CMAKE_SOURCE_DIR}/tests/app/run_test_query2_multi.sh ${CMAKE_BINARY_DIR}/app/kmindex/kmindex .
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests/data
+)

--- a/tests/app/run_test_query2_multi.sh
+++ b/tests/app/run_test_query2_multi.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+
+kmindex_bin=$1
+directory=$2
+
+cd ${directory}
+
+fail=0
+
+# Test 1: query2 with comma-separated individual index paths
+# should produce the same results as query2 with a single global index.
+#
+# indexes/index has both sub-indexes (abs, pa) in one global index.
+# indexes/abs_global has only abs, indexes/pa_global has only pa.
+# Passing comma-separated: abs_global,pa_global should merge them.
+
+rm -rf out_multi out_single
+
+# Run query2 with merged comma-separated paths (matrix format)
+${kmindex_bin} query2 -i indexes/abs_global,indexes/pa_global \
+                     -q datasets/abs_dataset/1.fasta \
+                     -z 4 \
+                     -f matrix \
+                     -o out_multi -t 2 2> /dev/null
+
+# Run query2 with single global index (matrix format)
+${kmindex_bin} query2 -i indexes/index \
+                     -q datasets/abs_dataset/1.fasta \
+                     -z 4 \
+                     -f matrix \
+                     -o out_single -t 2 2> /dev/null
+
+# Compare abs output (both should have abs.tsv)
+diff out_multi/abs.tsv out_single/abs.tsv || { echo "FAIL: abs.tsv differs (matrix)"; fail=1; }
+
+# Run query2 with merged comma-separated paths (json format)
+rm -rf out_multi out_single
+
+${kmindex_bin} query2 -i indexes/abs_global,indexes/pa_global \
+                     -q datasets/abs_dataset/1.fasta \
+                     -z 4 \
+                     -f json \
+                     -o out_multi -t 2 2> /dev/null
+
+${kmindex_bin} query2 -i indexes/index \
+                     -q datasets/abs_dataset/1.fasta \
+                     -z 4 \
+                     -f json \
+                     -o out_single -t 2 2> /dev/null
+
+diff out_multi/abs.json out_single/abs.json || { echo "FAIL: abs.json differs"; fail=1; }
+
+# Test 2: query2 with pa dataset
+rm -rf out_multi out_single
+
+${kmindex_bin} query2 -i indexes/abs_global,indexes/pa_global \
+                     -q datasets/pa_dataset/1.fasta \
+                     -z 5 \
+                     -f matrix \
+                     -o out_multi -t 2 2> /dev/null
+
+${kmindex_bin} query2 -i indexes/index \
+                     -q datasets/pa_dataset/1.fasta \
+                     -z 5 \
+                     -f matrix \
+                     -o out_single -t 2 2> /dev/null
+
+diff out_multi/pa.tsv out_single/pa.tsv || { echo "FAIL: pa.tsv differs (matrix)"; fail=1; }
+
+# Test 3: query2 with --names to select a single sub-index from merged set
+rm -rf out_multi out_single
+
+${kmindex_bin} query2 -i indexes/abs_global,indexes/pa_global \
+                     -n abs \
+                     -q datasets/abs_dataset/1.fasta \
+                     -z 4 \
+                     -f matrix \
+                     -o out_multi -t 2 2> /dev/null
+
+${kmindex_bin} query2 -i indexes/index \
+                     -n abs \
+                     -q datasets/abs_dataset/1.fasta \
+                     -z 4 \
+                     -f matrix \
+                     -o out_single -t 2 2> /dev/null
+
+diff out_multi/abs.tsv out_single/abs.tsv || { echo "FAIL: abs.tsv differs with --names"; fail=1; }
+
+# Test 4: query2 with single path (no comma) — backwards compatibility
+rm -rf out_single
+
+${kmindex_bin} query2 -i indexes/index \
+                     -n abs \
+                     -q datasets/abs_dataset/1.fasta \
+                     -z 4 \
+                     -f matrix \
+                     -o out_single -t 2 2> /dev/null
+
+diff out_single/abs.tsv outputs/q1_z4_abs.tsv || { echo "FAIL: single-path backwards compat"; fail=1; }
+
+# Test 5: query2 with all sub-indexes (default --names all) on merged paths
+# verifies both sub-indexes produce output files
+rm -rf out_multi out_single
+
+${kmindex_bin} query2 -i indexes/abs_global,indexes/pa_global \
+                     -q datasets/pa_dataset/1.fasta \
+                     -z 5 \
+                     -f matrix \
+                     -o out_multi -t 2 2> /dev/null
+
+# Both sub-indexes should produce output
+[ -f out_multi/abs.tsv ] || { echo "FAIL: abs.tsv missing from multi output"; fail=1; }
+[ -f out_multi/pa.tsv ] || { echo "FAIL: pa.tsv missing from multi output"; fail=1; }
+
+# Test 6: sub-index name collision should fail
+rm -rf out_collision
+${kmindex_bin} query2 -i indexes/index,indexes/abs_global \
+                     -q datasets/abs_dataset/1.fasta \
+                     -z 4 \
+                     -f matrix \
+                     -o out_collision -t 1 2> /dev/null
+if [ $? -eq 0 ]; then
+  echo "FAIL: expected error on sub-index name collision"; fail=1
+fi
+
+# Test 7: invalid path in comma-separated list should be rejected by CLI checker
+# CLI checker errors (BCliError) exit with code 0 but prevent the command from running,
+# so the output directory should not be created.
+rm -rf out_invalid
+${kmindex_bin} query2 -i indexes/abs_global,indexes/nonexistent \
+                     -q datasets/abs_dataset/1.fasta \
+                     -z 4 \
+                     -f matrix \
+                     -o out_invalid -t 1 2> /dev/null
+if [ -d out_invalid ]; then
+  echo "FAIL: expected CLI rejection on non-existent path in comma-separated list"; fail=1
+fi
+
+# Test 8: reversed merge order should produce same results as original order
+rm -rf out_multi out_multi_rev
+
+${kmindex_bin} query2 -i indexes/abs_global,indexes/pa_global \
+                     -q datasets/abs_dataset/1.fasta \
+                     -z 4 \
+                     -f matrix \
+                     -o out_multi -t 2 2> /dev/null
+
+${kmindex_bin} query2 -i indexes/pa_global,indexes/abs_global \
+                     -q datasets/abs_dataset/1.fasta \
+                     -z 4 \
+                     -f matrix \
+                     -o out_multi_rev -t 2 2> /dev/null
+
+diff out_multi/abs.tsv out_multi_rev/abs.tsv || { echo "FAIL: abs.tsv differs with reversed merge order"; fail=1; }
+diff out_multi/pa.tsv out_multi_rev/pa.tsv || { echo "FAIL: pa.tsv differs with reversed merge order"; fail=1; }
+
+rm -rf out_multi out_single out_collision out_invalid out_multi_rev
+
+if [ $fail -eq 0 ]; then
+  echo "All query2 multi-index tests passed."
+  exit 0
+else
+  exit 1
+fi

--- a/tests/data/indexes/abs_global/abs
+++ b/tests/data/indexes/abs_global/abs
@@ -1,0 +1,1 @@
+./indexes/abs_index

--- a/tests/data/indexes/abs_global/index.json
+++ b/tests/data/indexes/abs_global/index.json
@@ -1,0 +1,35 @@
+{
+    "index": {
+        "abs": {
+            "bloom_size": 800000,
+            "bw": 2,
+            "index_size": 3,
+            "kmindex_version": "0.2.0",
+            "kmtricks_version": "1.2.1",
+            "minim_size": 10,
+            "nb_partitions": 4,
+            "nb_samples": 16,
+            "samples": [
+                "D0",
+                "D1",
+                "D2",
+                "D3",
+                "D4",
+                "D5",
+                "D6",
+                "D7",
+                "D8",
+                "D9",
+                "D10",
+                "D11",
+                "D12",
+                "D13",
+                "D14",
+                "D15"
+            ],
+            "sha1": "6a0f7482d4533cf2fef2e44979a0d11912f18272",
+            "smer_size": 25
+        }
+    },
+    "path": "./indexes/abs_global"
+}

--- a/tests/data/indexes/pa_global/index.json
+++ b/tests/data/indexes/pa_global/index.json
@@ -1,0 +1,35 @@
+{
+    "index": {
+        "pa": {
+            "bloom_size": 800000,
+            "bw": 1,
+            "index_size": 1,
+            "kmindex_version": "0.2.0",
+            "kmtricks_version": "1.2.1",
+            "minim_size": 10,
+            "nb_partitions": 4,
+            "nb_samples": 16,
+            "samples": [
+                "D0",
+                "D1",
+                "D2",
+                "D3",
+                "D4",
+                "D5",
+                "D6",
+                "D7",
+                "D8",
+                "D9",
+                "D10",
+                "D11",
+                "D12",
+                "D13",
+                "D14",
+                "D15"
+            ],
+            "sha1": "7a0284634c173063e0a136e8628249be6f68ef36",
+            "smer_size": 25
+        }
+    },
+    "path": "./indexes/pa_global"
+}

--- a/tests/data/indexes/pa_global/pa
+++ b/tests/data/indexes/pa_global/pa
@@ -1,0 +1,1 @@
+./indexes/pa_index


### PR DESCRIPTION
Add --index comma-separated path support. Multiple global index directories are merged into one logical index, enabling the BRC Galaxy deployment to pass 109 individual index directories in a single invocation.

Library: index::merge() combines sub-indexes from another global index, throwing on name collision.

CLI: is_kmq_index checker splits on commas and validates each path. main_query2 loads the first path, then merges each additional path.

Tests: 8 tests — merged vs single global (matrix+json), pa dataset, --names filtering, backwards compat, all-subindex output, collision error, invalid path rejection, reversed merge order.

**Independent of memory gating. If both merge, memory gating's per-sub-index estimation will need to account for merged indexes.**